### PR TITLE
Automatic recording of score

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "externals/LR2Mem"]
 	path = externals/LR2Mem
 	url = git@github.com:MatVeiQaaa/LR2Mem.git
+[submodule "externals/safetyhook"]
+	path = externals/safetyhook
+	url = https://github.com/cursey/safetyhook.git

--- a/LR2SceneSwitcher.vcxproj
+++ b/LR2SceneSwitcher.vcxproj
@@ -86,7 +86,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)externals;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -106,7 +106,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)externals;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -151,6 +151,7 @@
     <ClInclude Include="include\opcodes.h" />
     <ClInclude Include="include\settings.h" />
     <ClInclude Include="include\currentDateTime.h" />
+    <ClInclude Include="include\uuid.h" />
     <ClInclude Include="include\websocket.h" />
     <ClInclude Include="include\memoryReading.h" />
     <ClInclude Include="include\pch.h" />

--- a/LR2SceneSwitcher.vcxproj.filters
+++ b/LR2SceneSwitcher.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="include\pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\uuid.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -17,6 +17,9 @@
 #include <sha256/sha256.c>
 #include <ctime>
 
+SafetyHookMid onSceneInitHook;
+SafetyHookMid onSceneLoopHook;
+
 using json = nlohmann::json;
 using namespace nlohmann::literals;
 
@@ -32,6 +35,12 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 	{
 	case DLL_PROCESS_ATTACH:
 		LoadSettings(hModule);
+
+		onSceneInitHook = safetyhook::create_mid((void*)((uintptr_t)GetModuleHandle(NULL) + 0x031BB6), onSceneInit);
+		onSceneLoopHook = safetyhook::create_mid((void*)((uintptr_t)GetModuleHandle(NULL) + 0x033746), onSceneLoop);
+
+		LR2::Init();
+		
 #ifdef _DEBUG
 		if (CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)StartWebSocketClient, nullptr, 0, nullptr) == nullptr) {
 			std::cout << currentDateTime() << "Failed to create WebSocket client thread\n";

--- a/include/memoryReading.h
+++ b/include/memoryReading.h
@@ -1,8 +1,18 @@
 #pragma once
 #include <websocket.h>
 
+struct playInfo {
+	std::string songName;
+	int lamp;
+	int totalNotes;
+	int exscore;
+	int pgreat;
+	int great;
+};
+
 extern bool reqRestartRecord;
 extern bool isCourseResult;
+extern playInfo _playInfo;
 
 int LR2Listen(WebSocketClient* client);
 void onSceneInit(SafetyHookContext& regs);

--- a/include/memoryReading.h
+++ b/include/memoryReading.h
@@ -3,3 +3,4 @@
 #include <websocket.h>
 
 int LR2Listen(WebSocketClient* client);
+void recordDelayTask(int currentProc, WebSocketClient& client);

--- a/include/memoryReading.h
+++ b/include/memoryReading.h
@@ -1,6 +1,10 @@
 #pragma once
-#include <LR2Mem/LR2Bindings.hpp>
 #include <websocket.h>
 
+extern bool reqRestartRecord;
+extern bool isCourseResult;
+
 int LR2Listen(WebSocketClient* client);
-void recordDelayTask(int currentProc, WebSocketClient& client);
+void onSceneInit(SafetyHookContext& regs);
+void onSceneLoop(SafetyHookContext& regs);
+void recordDelayTask(int sceneIdx);

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -14,3 +14,11 @@ std::string base64_encode(const unsigned char* data, unsigned int length);
 bool ReadOpCode(std::string message, WebSocketClient& client);
 void SendOpCode(std::string reqName, std::string argument, WebSocketClient& client);
 inline void SendOpCode(std::string reqName, WebSocketClient& client) { SendOpCode(reqName, "", client); };
+
+void recordRenameTask(std::string outputPath);
+
+// from LR2HackBox ScoreCannon.cpp
+constexpr const char* lamps[] = { "NO PLAY", "FAILED", "EASY CLEAR", "GROOVE CLEAR", "HARD CLEAR", "FULL COMBO", "PERFECT", "MAX", "ASSIST CLEAR", "NONE" };
+constexpr const char* grades[] = { "F", "E", "D", "C", "B", "A", "AA", "AAA", "MAX" };
+int getGrade();
+std::string convStr(const std::string& str);

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -12,4 +12,5 @@ std::string currentDateTime();
 std::string sha256_binary(const std::string& input);
 std::string base64_encode(const unsigned char* data, unsigned int length);
 bool ReadOpCode(std::string message, WebSocketClient& client);
-void SendOpCode(std::string argument, WebSocketClient& client);
+void SendOpCode(std::string reqName, std::string argument, WebSocketClient& client);
+inline void SendOpCode(std::string reqName, WebSocketClient& client) { SendOpCode(reqName, "", client); };

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -3,6 +3,7 @@
 #include "websocket.h"
 #include "settings.h"
 #include "memoryReading.h"
+#include "LR2Mem/LR2Bindings.hpp"
 #include <json/single_include/nlohmann/json.hpp>
 #include <string>
 

--- a/include/opcodes.h
+++ b/include/opcodes.h
@@ -16,10 +16,10 @@ bool ReadOpCode(std::string message, WebSocketClient& client);
 void SendOpCode(std::string reqName, std::string argument, WebSocketClient& client);
 inline void SendOpCode(std::string reqName, WebSocketClient& client) { SendOpCode(reqName, "", client); };
 
-void recordRenameTask(std::string outputPath);
+void recordRenameTask(std::string outputPath, playInfo playInfo);
 
 // from LR2HackBox ScoreCannon.cpp
 constexpr const char* lamps[] = { "NO PLAY", "FAILED", "EASY CLEAR", "GROOVE CLEAR", "HARD CLEAR", "FULL COMBO", "PERFECT", "MAX", "ASSIST CLEAR", "NONE" };
 constexpr const char* grades[] = { "F", "E", "D", "C", "B", "A", "AA", "AAA", "MAX" };
-int getGrade();
+int getGrade(int pgreat, int great, int totalNotes);
 std::string convStr(const std::string& str);

--- a/include/pch.h
+++ b/include/pch.h
@@ -18,3 +18,4 @@
 #include <fstream>
 #include <vector>
 #include <json/single_include/nlohmann/json.hpp>
+#include <safetyhook/include/safetyhook.hpp>

--- a/include/settings.h
+++ b/include/settings.h
@@ -13,6 +13,7 @@ struct Settings {
     std::string resultScene;
     int rpcVersion;
     bool authenticated;
+    int recordType; // 0 - Disable, 1 - Record, 2 - ReplayBuffer
 };
 
 extern Settings settings;

--- a/include/settings.h
+++ b/include/settings.h
@@ -11,6 +11,7 @@ struct Settings {
     std::string selectScene;
     std::string playScene;
     std::string resultScene;
+    std::string courseResultScene;
     int rpcVersion;
     bool authenticated;
     int recordType = 0; // 0 - Disable, 1 - Record, 2 - ReplayBuffer

--- a/include/settings.h
+++ b/include/settings.h
@@ -13,7 +13,10 @@ struct Settings {
     std::string resultScene;
     int rpcVersion;
     bool authenticated;
-    int recordType; // 0 - Disable, 1 - Record, 2 - ReplayBuffer
+    int recordType = 0; // 0 - Disable, 1 - Record, 2 - ReplayBuffer
+    int recordShortcutKey = 0x75; // shortcut key for recording (stop in Record, save in ReplayBuffer)
+    int recordStartDelay = 0; // delay start recording (in milliseconds)
+    int recordEndDelay = 0; // delay stop recording (in milliseconds)
 };
 
 extern Settings settings;

--- a/include/uuid.h
+++ b/include/uuid.h
@@ -1,0 +1,36 @@
+#include <random>
+#include <sstream>
+
+namespace uuid {
+    static std::random_device              rd;
+    static std::mt19937                    gen(rd());
+    static std::uniform_int_distribution<> dis(0, 15);
+    static std::uniform_int_distribution<> dis2(8, 11);
+
+    std::string generate_uuid_v4() {
+        std::stringstream ss;
+        int i;
+        ss << std::hex;
+        for (i = 0; i < 8; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 4; i++) {
+            ss << dis(gen);
+        }
+        ss << "-4";
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        ss << dis2(gen);
+        for (i = 0; i < 3; i++) {
+            ss << dis(gen);
+        }
+        ss << "-";
+        for (i = 0; i < 12; i++) {
+            ss << dis(gen);
+        };
+        return ss.str();
+    }
+}

--- a/src/memoryReading.cpp
+++ b/src/memoryReading.cpp
@@ -7,6 +7,7 @@
 #include <future>
 
 WebSocketClient* webSocketClient = {};
+playInfo _playInfo = {};
 bool wasInitialized = false;
 bool hasRequestRecordingStop = false;
 bool isCourseResult = false;
@@ -90,6 +91,7 @@ void onSceneInit(SafetyHookContext& regs) {
 
 void onSceneLoop(SafetyHookContext& regs) {
     if (!wasInitialized) return;
+    if (!LR2::isInit) return;
 
     switch (regs.eax) {
     case 5:
@@ -97,6 +99,18 @@ void onSceneLoop(SafetyHookContext& regs) {
         if (settings.recordType > 0) {
             if (GetAsyncKeyState(settings.recordShortcutKey) & 0x8000) {
                 if (!hasRequestRecordingStop) {
+                    {
+                        _playInfo.songName = convStr(LR2::pGame->sSelect.metaSelected.title.body);
+                        _playInfo.lamp = LR2::pGame->gameplay.player[0].clearType;
+                        _playInfo.totalNotes = LR2::pGame->gameplay.player[0].totalnotes;
+                        _playInfo.exscore = LR2::pGame->gameplay.player[0].exscore;
+                        _playInfo.pgreat = LR2::pGame->gameplay.player[0].judgecount[5];
+                        _playInfo.great = LR2::pGame->gameplay.player[0].judgecount[4];
+
+                        if ((LR2::pGame->gameplay.courseType == 0 || LR2::pGame->gameplay.courseType == 2) && !isCourseResult)
+                            _playInfo.songName = convStr(LR2::pGame->sSelect.bmsList[LR2::pGame->sSelect.cur_song].courseTitle[LR2::pGame->gameplay.courseStageNow].body);
+                    }
+
                     switch (settings.recordType) {
                     case 1:
                         SendOpCode("StopRecord", *webSocketClient);

--- a/src/memoryReading.cpp
+++ b/src/memoryReading.cpp
@@ -89,6 +89,10 @@ int LR2Listen(WebSocketClient* client) {
                     std::cout << currentDateTime() << "Requesting change to result scene.\n";
                     SendOpCode("SetCurrentProgramScene", settings.resultScene, *client);
                     break;
+                case 13:
+                    // TODO:: COURSE RESULT
+                    // transition goes to 5 -> 2 -> 13
+                    break;
                 default:
                     std::cout << currentDateTime() << "Unhandled procSelecter value: " << currentProc << std::endl;
                     break;
@@ -114,6 +118,7 @@ void recordDelayTask(int currentProc, WebSocketClient& client) {
             else hasRequestRecordingStop = false;
             break;
         case 2:
+            if (hasRequestRecordingStop) hasRequestRecordingStop = false;
             SendOpCode("StopReplayBuffer", client);
             break;
 

--- a/src/memoryReading.cpp
+++ b/src/memoryReading.cpp
@@ -89,6 +89,8 @@ void onSceneInit(SafetyHookContext& regs) {
 }
 
 void onSceneLoop(SafetyHookContext& regs) {
+    if (!wasInitialized) return;
+
     switch (regs.eax) {
     case 5:
     case 13:
@@ -118,6 +120,8 @@ void onSceneLoop(SafetyHookContext& regs) {
 }
 
 void recordDelayTask(int sceneIdx) {
+    if (!wasInitialized) return;
+
     switch (sceneIdx) {
     case 2:
     case 13:

--- a/src/memoryReading.cpp
+++ b/src/memoryReading.cpp
@@ -6,120 +6,130 @@
 #include "opcodes.h"
 #include <future>
 
-BOOL hasRequestRecordingStop = false;
+WebSocketClient* webSocketClient = {};
+bool wasInitialized = false;
+bool hasRequestRecordingStop = false;
+bool isCourseResult = false;
+bool reqRestartRecord = false;
+int currentSceneIdx = -1;
+int previousSceneIdx = -1;
 
 int LR2Listen(WebSocketClient* client) {
-    std::cout << currentDateTime() << "LR2Listen started, performing initial checks...\n";
+    std::cout << currentDateTime() << "LR2Listen started...\n";
+    webSocketClient = client;
 
-    int lastProcSelecter = -1;
-    int currentProc = -1;
-    int recordType = settings.recordType;
-    bool wasInitialized = false;
-    bool isResult = false;
-   
     while (client->isConnected()) {
-        if (!LR2::isInit) {
-            if (wasInitialized) {
-                std::cout << currentDateTime() << "LR2 initialization lost, attempting to reinitialize...\n";
-                wasInitialized = false;
-            }
+        if (!wasInitialized) wasInitialized = true;
 
-            LR2::Init();
-
-            if (LR2::isInit) {
-                std::cout << currentDateTime() << "LR2 successfully initialized!\n";
-                std::cout << currentDateTime() << "pGame address: " << std::hex << LR2::pGame
-                    << ", procSelecter offset: " << std::hex << &(LR2::pGame->procSelecter) << std::dec << std::endl;
-                wasInitialized = true;
-            }
-            else {
-                std::this_thread::sleep_for(std::chrono::seconds(2));
-                continue;
-            }
-        }
-
-        if (LR2::isInit) {
-            wasInitialized = true;
-            currentProc = LR2::pGame->procSelecter;
-            isResult = currentProc == 5;
-
-            if (isResult && recordType > 0) {
-                if (GetAsyncKeyState(settings.recordShortcutKey) & 0x8000) {
-                    if (!hasRequestRecordingStop) {
-                        switch (recordType) {
-                        case 1:
-                            SendOpCode("StopRecord", *client);
-                            break;
-                        case 2:
-                            SendOpCode("SaveReplayBuffer", *client);
-                            break;
-
-                        default:
-                            break;
-                        }
-                        hasRequestRecordingStop = true;
-                    }
-                }
-            }
-
-            if (currentProc != lastProcSelecter) {
-                std::cout << currentDateTime() << "procSelecter changed from "
-                    << lastProcSelecter << " to " << currentProc << std::endl;
-
-                switch (currentProc) {
-                case 2:
-                    if (settings.recordType > 0) {
-                        std::cout << currentDateTime() << "Requesting stop recording.\n";
-                        std::async(std::launch::async, recordDelayTask, currentProc, std::ref(*client));
-                    }
-                    std::cout << currentDateTime() << "Requesting change to song select scene.\n";
-                    SendOpCode("SetCurrentProgramScene", settings.selectScene, *client);
-                    break;
-                case 3:
-                    if (settings.recordType > 0) {
-                        std::cout << currentDateTime() << "Requesting start recording.\n";
-                        std::async(std::launch::async, recordDelayTask, currentProc, std::ref(*client));
-                    }
-                    break;
-                case 4:
-                    std::cout << currentDateTime() << "Requesting change to play scene.\n";
-                    SendOpCode("SetCurrentProgramScene", settings.playScene, *client);
-                    break;
-                case 5:
-                    std::cout << currentDateTime() << "Requesting change to result scene.\n";
-                    SendOpCode("SetCurrentProgramScene", settings.resultScene, *client);
-                    break;
-                case 13:
-                    // TODO:: COURSE RESULT
-                    // transition goes to 5 -> 2 -> 13
-                    break;
-                default:
-                    std::cout << currentDateTime() << "Unhandled procSelecter value: " << currentProc << std::endl;
-                    break;
-                }
-
-                lastProcSelecter = currentProc;
-            }
-        }
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::seconds(5));
     }
 
+    std::cout << currentDateTime() << "WebSocket connection has been lost..." << std::endl;
+    wasInitialized = false;
     return 0;
 }
 
-void recordDelayTask(int currentProc, WebSocketClient& client) {
-    switch (currentProc) {
+void onSceneInit(SafetyHookContext& regs) {
+    if (!wasInitialized) return;
+    currentSceneIdx = regs.eax;
+
+    switch (currentSceneIdx) {
     case 2:
+        if (settings.recordType > 0) {
+            std::cout << currentDateTime() << "Requesting stop recording.\n";
+            std::async(std::launch::async, recordDelayTask, currentSceneIdx);
+        }
+        std::cout << currentDateTime() << "Requesting change to song select scene.\n";
+        SendOpCode("SetCurrentProgramScene", settings.selectScene, *webSocketClient);
+        break;
+    case 3:
+        if (settings.recordType > 0) {
+            std::cout << currentDateTime() << "Requesting start recording.\n";
+            std::async(std::launch::async, recordDelayTask, currentSceneIdx);
+        }
+        break;
+    case 4:
+        std::cout << currentDateTime() << "Requesting change to play scene.\n";
+        if (settings.recordType > 0) {
+            if (previousSceneIdx == currentSceneIdx || previousSceneIdx == 5) { // quick restart or restart //
+                std::cout << currentDateTime() << "Restart record request detected\n";
+                reqRestartRecord = true;
+
+                switch (settings.recordType) {
+                case 1:
+                    SendOpCode("StopRecord", *webSocketClient);
+                    break;
+                case 2:
+                    SendOpCode("StopReplayBuffer", *webSocketClient);
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+        SendOpCode("SetCurrentProgramScene", settings.playScene, *webSocketClient);
+        break;
+    case 5:
+        std::cout << currentDateTime() << "Requesting change to result scene.\n";
+        SendOpCode("SetCurrentProgramScene", settings.resultScene, *webSocketClient);
+        break;
+    case 13:
+        std::cout << currentDateTime() << "Requesting change to course result scene.\n";
+        SendOpCode("SetCurrentProgramScene", settings.courseResultScene, *webSocketClient);
+        isCourseResult = true;
+        break;
+
+    default:
+        std::cout << currentDateTime() << "Unhandled scene index value: " << currentSceneIdx << std::endl;
+        break;
+    }
+
+    previousSceneIdx = currentSceneIdx;
+}
+
+void onSceneLoop(SafetyHookContext& regs) {
+    switch (regs.eax) {
+    case 5:
+    case 13:
+        if (settings.recordType > 0) {
+            if (GetAsyncKeyState(settings.recordShortcutKey) & 0x8000) {
+                if (!hasRequestRecordingStop) {
+                    switch (settings.recordType) {
+                    case 1:
+                        SendOpCode("StopRecord", *webSocketClient);
+                        break;
+                    case 2:
+                        SendOpCode("SaveReplayBuffer", *webSocketClient);
+                        break;
+
+                    default:
+                        break;
+                    }
+                    hasRequestRecordingStop = true;
+                }
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+void recordDelayTask(int sceneIdx) {
+    switch (sceneIdx) {
+    case 2:
+    case 13:
         if (settings.recordEndDelay > 0) std::this_thread::sleep_for(std::chrono::milliseconds(settings.recordEndDelay));
         switch (settings.recordType) {
         case 1:
-            if (!hasRequestRecordingStop) SendOpCode("StopRecord", client);
+            if (!hasRequestRecordingStop) SendOpCode("StopRecord", *webSocketClient);
             else hasRequestRecordingStop = false;
             break;
         case 2:
             if (hasRequestRecordingStop) hasRequestRecordingStop = false;
-            SendOpCode("StopReplayBuffer", client);
+            SendOpCode("StopReplayBuffer", *webSocketClient);
             break;
 
         default:
@@ -130,10 +140,10 @@ void recordDelayTask(int currentProc, WebSocketClient& client) {
         if (settings.recordStartDelay > 0) std::this_thread::sleep_for(std::chrono::milliseconds(settings.recordStartDelay));
         switch (settings.recordType) {
         case 1:
-            SendOpCode("StartRecord", client);
+            SendOpCode("StartRecord", *webSocketClient);
             break;
         case 2:
-            SendOpCode("StartReplayBuffer", client);
+            SendOpCode("StartReplayBuffer", *webSocketClient);
             break;
 
         default:

--- a/src/opcodes.cpp
+++ b/src/opcodes.cpp
@@ -104,12 +104,14 @@ bool ReadOpCode(std::string message, WebSocketClient& client) {
     }
 }
 
-void SendOpCode(std::string argument, WebSocketClient& client) {
+void SendOpCode(std::string reqName, std::string argument, WebSocketClient& client) {
     json data;
     data["op"] = 6;
-    data["d"]["requestType"] = "SetCurrentProgramScene";
+    data["d"]["requestType"] = reqName;
     data["d"]["requestId"] = "idk whats this";
-    data["d"]["requestData"]["sceneName"] = argument;
+    if (reqName._Equal("SetCurrentProgramScene") && !argument.empty()) {
+        data["d"]["requestData"]["sceneName"] = argument;
+    }
 
     std::string datadump = data.dump();
     client.sendMessage(datadump);

--- a/src/opcodes.cpp
+++ b/src/opcodes.cpp
@@ -101,7 +101,7 @@ bool ReadOpCode(std::string message, WebSocketClient& client) {
                 std::string outputState = msgSerialized["d"]["eventData"]["outputState"];
                 if (outputState.compare("OBS_WEBSOCKET_OUTPUT_STOPPED") != 0) return true;
 
-                std::this_thread::sleep_for(std::chrono::milliseconds(50)); // for some reason even we waited for STOPPED event and send start request it won't start
+                std::this_thread::sleep_for(std::chrono::milliseconds(100)); // for some reason even we waited for STOPPED event and send start request it won't start
                 
                 SendOpCode("StartReplayBuffer", client);
                 reqRestartRecord = false;
@@ -112,7 +112,7 @@ bool ReadOpCode(std::string message, WebSocketClient& client) {
                 std::string outputState = msgSerialized["d"]["eventData"]["outputState"];
                 if (outputState.compare("OBS_WEBSOCKET_OUTPUT_STOPPED") == 0) {
                     if (reqRestartRecord) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(50)); // same reason as above
+                        std::this_thread::sleep_for(std::chrono::milliseconds(100)); // same reason as above
 
                         SendOpCode("StartRecord", client);
                         reqRestartRecord = false;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -57,6 +57,7 @@ void LoadSettings(HMODULE hModule) {
 			L"selectScene = \n"
 			L"playScene = \n"
 			L"resultScene = \n"
+			L"courseResultScene = \n"
 			L"# Set your record related settings in here.\n"
 			L"# Available types are 1 for Recoding and 2 for ReplayBuffer\n"
 			L"# Default Record Shortcut Key is F6 (0x75)\n"
@@ -122,6 +123,11 @@ void LoadSettings(HMODULE hModule) {
 				std::string resultScene(wresultScene.begin(), wresultScene.end());
 				settings.resultScene = resultScene;
 			}
+			if (line.starts_with(L"courseResultScene = ")) {
+				std::wstring wcourseResultScene = line.substr(std::wstring_view(L"courseResultScene = ").length());
+				std::string courseResultScene(wcourseResultScene.begin(), wcourseResultScene.end());
+				settings.courseResultScene = courseResultScene;
+			}
 			if (line.starts_with(L"recordType = ")) {
 				std::wstring wrecordType = line.substr(std::wstring_view(L"recordType = ").length());
 				int recordType = std::stoi(wrecordType);
@@ -153,6 +159,7 @@ void LoadSettings(HMODULE hModule) {
 			<< "\nSelect Scene: " << settings.selectScene
 			<< "\nPlay Scene: " << settings.playScene
 			<< "\nResult Scene: " << settings.resultScene
+			<< "\nCourse Result Scene: " << settings.courseResultScene
 			<< "\nRecord Type: " << settings.recordType
 			<< "\nRecord Shortcut Key: 0x" << std::hex << settings.recordShortcutKey
 			<< "\nRecord Start Delay: " << settings.recordStartDelay

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -57,8 +57,14 @@ void LoadSettings(HMODULE hModule) {
 			L"selectScene = \n"
 			L"playScene = \n"
 			L"resultScene = \n"
-			L"# Set your record type in here.\n"
-			L"recordType = 0\n";
+			L"# Set your record related settings in here.\n"
+			L"# Available types are 1 for Recoding and 2 for ReplayBuffer\n"
+			L"# Default Record Shortcut Key is F6 (0x75)\n"
+			L"# Delays are in milliseconds\n"
+			L"recordType = 0\n"
+			L"recordShortcutKey = 0x75\n"
+			L"recordStartDelay = 0\n"
+			L"recordEndDelay = 0\n";
 		settings_list.open(settings_path, std::ios::out | std::ios::trunc);
 		settings_list << settingstemplate;
 		settings_list.close();
@@ -121,6 +127,21 @@ void LoadSettings(HMODULE hModule) {
 				int recordType = std::stoi(wrecordType);
 				settings.recordType = recordType;
 			}
+			if (line.starts_with(L"recordShortcutKey = ")) {
+				std::wstring wrecordShortcutKey = line.substr(std::wstring_view(L"recordShortcutKey = ").length());
+				int recordShortcutKey = std::stoi(wrecordShortcutKey, nullptr, 16);
+				settings.recordShortcutKey = recordShortcutKey;
+			}
+			if (line.starts_with(L"recordStartDelay = ")) {
+				std::wstring wrecordStartDelay = line.substr(std::wstring_view(L"recordStartDelay = ").length());
+				int recordStartDelay = std::stoi(wrecordStartDelay);
+				settings.recordStartDelay = recordStartDelay;
+			}
+			if (line.starts_with(L"recordEndDelay = ")) {
+				std::wstring wrecordEndDelay = line.substr(std::wstring_view(L"recordEndDelay = ").length());
+				int recordEndDelay = std::stoi(wrecordEndDelay);
+				settings.recordEndDelay = recordEndDelay;
+			}
 			// Heyy! That's still less bloated than Tachi Score Importer!!!
 		}
 
@@ -133,6 +154,9 @@ void LoadSettings(HMODULE hModule) {
 			<< "\nPlay Scene: " << settings.playScene
 			<< "\nResult Scene: " << settings.resultScene
 			<< "\nRecord Type: " << settings.recordType
+			<< "\nRecord Shortcut Key: 0x" << std::hex << settings.recordShortcutKey
+			<< "\nRecord Start Delay: " << settings.recordStartDelay
+			<< "\nRecord End Delay: " << settings.recordEndDelay
 			<< std::endl;
 	}
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -56,7 +56,9 @@ void LoadSettings(HMODULE hModule) {
 			L"# Type your OBS scene names here.\n"
 			L"selectScene = \n"
 			L"playScene = \n"
-			L"resultScene = \n";
+			L"resultScene = \n"
+			L"# Set your record type in here.\n"
+			L"recordType = 0\n";
 		settings_list.open(settings_path, std::ios::out | std::ios::trunc);
 		settings_list << settingstemplate;
 		settings_list.close();
@@ -114,6 +116,11 @@ void LoadSettings(HMODULE hModule) {
 				std::string resultScene(wresultScene.begin(), wresultScene.end());
 				settings.resultScene = resultScene;
 			}
+			if (line.starts_with(L"recordType = ")) {
+				std::wstring wrecordType = line.substr(std::wstring_view(L"recordType = ").length());
+				int recordType = std::stoi(wrecordType);
+				settings.recordType = recordType;
+			}
 			// Heyy! That's still less bloated than Tachi Score Importer!!!
 		}
 
@@ -125,6 +132,7 @@ void LoadSettings(HMODULE hModule) {
 			<< "\nSelect Scene: " << settings.selectScene
 			<< "\nPlay Scene: " << settings.playScene
 			<< "\nResult Scene: " << settings.resultScene
+			<< "\nRecord Type: " << settings.recordType
 			<< std::endl;
 	}
 }


### PR DESCRIPTION
draft of automated record support.

in LR2SceneSwitcher.ini add following line to enable :
recordType = 1 (for Recording)
recordType = 2 (for ReplayBuffer)

Recording will starts at decide scene and stops when you get back to select music scene (in this case recording won't be save on ReplayBuffer mode)
or press F6 on result scene.

pre-built binary is availble on fork release.

[sample video with ReplayBuffer mode](https://www.youtube.com/watch?v=r8pcarEavkQ)